### PR TITLE
Feature/#14/validate image upload

### DIFF
--- a/mogong/src/docs/asciidoc/team/team_create.adoc
+++ b/mogong/src/docs/asciidoc/team/team_create.adoc
@@ -37,11 +37,11 @@ Request Body 로 업로드가 완료된 Image URL을 보내야 합니다.
 
 operation::team_upload_test/upload_team_success[snippets='http-request,request-body,request-fields']
 
-===== Response(팀원들이 모두 이미지 업로드가 안된 상태일 때)
+===== Response(팀원들이 모두 이미지 업로드가 안 된 상태일 때)
 
 operation::team_upload_test/upload_team_success[snippets='http-response,response-body,response-fields']
 
-===== Response(팀원들이 모두 이미지 업로드가 안된 상태일 때)
+===== Response(팀원들이 모두 이미지 업로드가 된 상태일 때)
 
 operation::team_upload_test/completed_upload_team_success[snippets='response-body,response-fields']
 
@@ -71,20 +71,20 @@ API : `GET /teams/{teamId}/results?auth_code=1234`
 
 ==== 200 OK
 
-===== Request(이미지 제출 수 미충족, 성공, 올바른 auth_cde를 입력한 경우)
+===== Request(이미지 제출 수 미충족, 성공, 올바른 auth_code를 입력한 경우)
 
 operation::team_result_test/result_team_with_auth_code[snippets='http-request']
 
 
-===== Response(이미지 제출 수 미충족, 성공, 올바른 auth_cde를 입력한 경우)
+===== Response(이미지 제출 수 미충족, 성공, 올바른 auth_code를 입력한 경우)
 
 operation::team_result_test/result_team_with_auth_code[snippets='response-body']
 
 
-===== Request(이미지 제출 수 미충족, 실패, 잘못된 auth_cde를 입력한 경우)
+===== Request(이미지 제출 수 미충족, 실패, 잘못된 auth_code를 입력한 경우)
 
 operation::team_result_test/result_team_with_wrong_auth_code[snippets='http-request']
 
-===== Response(이미지 제출 수 미충족, 실패, 잘못된 auth_cde를 입력한 경우)
+===== Response(이미지 제출 수 미충족, 실패, 잘못된 auth_code를 입력한 경우)
 
 operation::team_result_test/result_team_with_wrong_auth_code[snippets='response-body']

--- a/mogong/src/main/java/hufs/team/mogong/common/exception/ErrorCodeAndMessages.java
+++ b/mogong/src/main/java/hufs/team/mogong/common/exception/ErrorCodeAndMessages.java
@@ -17,6 +17,7 @@ public enum ErrorCodeAndMessages implements CodeAndMessages {
 	NOT_FOUND_TEAM_ID("T-F001", "해당 팀 ID를 찾을 수 없습니다."),
 	NOT_COMPLETED_SUBMIT("T-F002", "현재 등록된 이미지 수가 지정된 멤버 수보다 적습니다."),
 	NOT_MATCH_AUTH_CODE("T-F003", "AUTH CODE가 일치하지 않습니다."),
+	UN_VALID_IMAGE_URL("T-F004", "시간표 이미지가 아닙니다. 이미지를 다시 확인해주세요."),
 	;
 	private final String code;
 	private final String message;

--- a/mogong/src/main/java/hufs/team/mogong/common/exception/GlobalExceptionHandler.java
+++ b/mogong/src/main/java/hufs/team/mogong/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package hufs.team.mogong.common.exception;
 
 import hufs.team.mogong.common.response.BaseResponse;
+import hufs.team.mogong.team.exception.NotCompletedSubmit;
+import hufs.team.mogong.team.service.dto.response.SubmitResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,6 +15,15 @@ public class GlobalExceptionHandler {
 	public BaseResponse<Void> handleConversionFailed(BaseException e) {
 		log.warn("Error Code={}, Error Message={}", e.getCode(), e.getMessage());
 		return BaseResponse.error(e.getCode(), e.getMessage());
+	}
+
+	@ExceptionHandler(NotCompletedSubmit.class)
+	public BaseResponse<SubmitResponse> handleNotCompletedSubmit(NotCompletedSubmit e) {
+		log.debug("[NOT COMPLETED SUBMIT] 현재 이미지 요청 수 = {}", e.getSizeOfImages());
+		return new BaseResponse<>(
+			e.getCode(),
+			e.getMessage(),
+			new SubmitResponse(e.getSizeOfImages(), e.getNumberOfTeam()));
 	}
 
 }

--- a/mogong/src/main/java/hufs/team/mogong/team/exception/NotCompletedSubmit.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/exception/NotCompletedSubmit.java
@@ -2,10 +2,17 @@ package hufs.team.mogong.team.exception;
 
 import hufs.team.mogong.common.exception.BaseException;
 import hufs.team.mogong.common.exception.ErrorCodeAndMessages;
+import lombok.Getter;
 
+@Getter
 public class NotCompletedSubmit extends BaseException {
 
-	public NotCompletedSubmit() {
+	private final int sizeOfImages;
+	private final int numberOfTeam;
+
+	public NotCompletedSubmit(int sizeOfImages, int numberOfTeam) {
 		super(ErrorCodeAndMessages.NOT_COMPLETED_SUBMIT);
+		this.sizeOfImages = sizeOfImages;
+		this.numberOfTeam = numberOfTeam;
 	}
 }

--- a/mogong/src/main/java/hufs/team/mogong/team/exception/UnValidImageUrl.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/exception/UnValidImageUrl.java
@@ -1,0 +1,11 @@
+package hufs.team.mogong.team.exception;
+
+import hufs.team.mogong.common.exception.BaseException;
+import hufs.team.mogong.common.exception.ErrorCodeAndMessages;
+
+public class UnValidImageUrl extends BaseException {
+
+	public UnValidImageUrl() {
+		super(ErrorCodeAndMessages.UN_VALID_IMAGE_URL);
+	}
+}

--- a/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
@@ -104,7 +104,7 @@ public class TeamService {
 		List<Image> images = imageRepository.findAllByTeam_TeamId(teamId);
 
 		if (isNull(authCode) && !checkImageSize(team, images)) {
-			throw new NotCompletedSubmit();
+			throw new NotCompletedSubmit(images.size(), team.getNumberOfMember());
 		}
 
 		if (!isNull(authCode) && !Objects.equals(team.getAuthCode(), authCode)) {

--- a/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
@@ -8,6 +8,7 @@ import hufs.team.mogong.team.Team;
 import hufs.team.mogong.team.exception.NotCompletedSubmit;
 import hufs.team.mogong.team.exception.NotFoundTeamIdException;
 import hufs.team.mogong.team.exception.NotMatchAuthCode;
+import hufs.team.mogong.team.exception.UnValidImageUrl;
 import hufs.team.mogong.team.repository.TeamRepository;
 import hufs.team.mogong.team.service.dto.request.CreateTeamRequest;
 import hufs.team.mogong.team.service.dto.request.ImageUrlRequest;
@@ -32,10 +33,13 @@ import org.springframework.web.client.RestTemplate;
 public class TeamService {
 
 	private static final int ZERO = 0;
+	@Value("${image-server.validate}")
+	private String imageValidateUrl;
 	@Value("${image-server.url}")
 	private String imageServerUrl;
 
 	private final TeamRepository teamRepository;
+
 	private final ImageRepository imageRepository;
 	private final RestTemplate restTemplate;
 	private final ImageUploadService imageUploadService;
@@ -67,6 +71,10 @@ public class TeamService {
 
 		log.debug("[요청 전 IMAGE 제출 수] {}", imageSize);
 		if (!checkImageSize(team, images)) {
+			/*
+			 * TODO RestTemplate을 통해 Flask에 요청하고 받는 부분 WireMock으로 지정하여 테스트까지 완료하기
+			 */
+//			validateImage(request.getImageUrl());
 			imageRepository.save(new Image(team, request.getImageUrl()));
 			imageSize++;
 		}
@@ -76,6 +84,18 @@ public class TeamService {
 			team.getTeamName(),
 			team.getNumberOfMember(),
 			imageSize);
+	}
+
+	private void validateImage(String imageUrl) {
+		Boolean isValidated = restTemplate.postForObject(
+			imageValidateUrl,
+			imageUrl,
+			Boolean.class
+		);
+		log.debug("IMAGE VALIDATE = {}", isValidated);
+		if (Boolean.FALSE.equals(isValidated)) {
+			throw new UnValidImageUrl();
+		}
 	}
 
 	public TeamResultResponse getResult(Long teamId, String authCode) {
@@ -99,7 +119,7 @@ public class TeamService {
 	}
 
 	private boolean checkImageSize(Team team, List<Image> images) {
-		return team.getNumberOfMember() == images.size();
+		return team.getNumberOfMember() <= images.size();
 	}
 
 	private boolean isNull(String authCode){

--- a/mogong/src/main/java/hufs/team/mogong/team/service/dto/request/UploadTeamRequest.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/service/dto/request/UploadTeamRequest.java
@@ -12,5 +12,5 @@ import org.hibernate.validator.constraints.URL;
 public class UploadTeamRequest {
 
 	@URL
-	public String imageUrl;
+	private String imageUrl;
 }

--- a/mogong/src/main/java/hufs/team/mogong/team/service/dto/response/SubmitResponse.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/service/dto/response/SubmitResponse.java
@@ -1,0 +1,15 @@
+package hufs.team.mogong.team.service.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class SubmitResponse {
+
+	private Integer submit;
+	private Integer numberOfTeam;
+}

--- a/mogong/src/main/resources/static/docs/index.html
+++ b/mogong/src/main/resources/static/docs/index.html
@@ -566,7 +566,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 26 Mar 2023 12:57:46 GMT
+Date: Tue, 04 Apr 2023 07:41:30 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 287
@@ -575,8 +575,8 @@ Content-Length: 287
   "code" : "I-S001",
   "message" : "이미지 PreSigned URL 생성에 성공했습니다.",
   "data" : {
-    "preSignedUrl" : "http://localhost:5050/local-embedded-bucket/image/906cdcca-7bd7-403d-86d6-119d1fbf70fe.JPG",
-    "fileName" : "906cdcca-7bd7-403d-86d6-119d1fbf70fe.JPG"
+    "preSignedUrl" : "http://localhost:5050/local-embedded-bucket/image/8d61c973-c519-432b-937e-c80472373b35.JPG",
+    "fileName" : "8d61c973-c519-432b-937e-c80472373b35.JPG"
   }
 }</code></pre>
 </div>
@@ -590,8 +590,8 @@ Content-Length: 287
   "code" : "I-S001",
   "message" : "이미지 PreSigned URL 생성에 성공했습니다.",
   "data" : {
-    "preSignedUrl" : "http://localhost:5050/local-embedded-bucket/image/906cdcca-7bd7-403d-86d6-119d1fbf70fe.JPG",
-    "fileName" : "906cdcca-7bd7-403d-86d6-119d1fbf70fe.JPG"
+    "preSignedUrl" : "http://localhost:5050/local-embedded-bucket/image/8d61c973-c519-432b-937e-c80472373b35.JPG",
+    "fileName" : "8d61c973-c519-432b-937e-c80472373b35.JPG"
   }
 }</code></pre>
 </div>
@@ -755,7 +755,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 26 Mar 2023 12:57:46 GMT
+Date: Tue, 04 Apr 2023 07:41:30 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 233
@@ -765,7 +765,7 @@ Content-Length: 233
   "message" : "팀 생성에 성공했습니다.",
   "data" : {
     "teamId" : 1,
-    "teamName" : "879bb0a1-99e0-4079-8d5e-f24920fd1ddf",
+    "teamName" : "70ccbc2c-52f4-45aa-aaa5-f308e60ac079",
     "numberOfTeam" : 5,
     "submit" : 0,
     "authCode" : "1234"
@@ -783,7 +783,7 @@ Content-Length: 233
   "message" : "팀 생성에 성공했습니다.",
   "data" : {
     "teamId" : 1,
-    "teamName" : "879bb0a1-99e0-4079-8d5e-f24920fd1ddf",
+    "teamName" : "70ccbc2c-52f4-45aa-aaa5-f308e60ac079",
     "numberOfTeam" : 5,
     "submit" : 0,
     "authCode" : "1234"
@@ -913,9 +913,9 @@ Content-Length: 56
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때">Response(팀원들이 모두 이미지 업로드가 안된 상태일 때)</a></h5>
+<h5 id="_response팀원들이_모두_이미지_업로드가_안_된_상태일_때"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안_된_상태일_때">Response(팀원들이 모두 이미지 업로드가 안 된 상태일 때)</a></h5>
 <div class="sect5">
-<h6 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_http_response"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_http_response">HTTP response</a></h6>
+<h6 id="_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_http_response"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_http_response">HTTP response</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
@@ -924,7 +924,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 26 Mar 2023 12:57:49 GMT
+Date: Tue, 04 Apr 2023 07:41:33 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 228
@@ -943,7 +943,7 @@ Content-Length: 228
 </div>
 </div>
 <div class="sect5">
-<h6 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_response_body"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_response_body">Response body</a></h6>
+<h6 id="_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_response_body"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_response_body">Response body</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code>{
@@ -960,7 +960,7 @@ Content-Length: 228
 </div>
 </div>
 <div class="sect5">
-<h6 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_response_fields"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_response_fields">Response fields</a></h6>
+<h6 id="_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_response_fields"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안_된_상태일_때_response_fields">Response fields</a></h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1010,9 +1010,9 @@ Content-Length: 228
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2">Response(팀원들이 모두 이미지 업로드가 안된 상태일 때)</a></h5>
+<h5 id="_response팀원들이_모두_이미지_업로드가_된_상태일_때"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_된_상태일_때">Response(팀원들이 모두 이미지 업로드가 된 상태일 때)</a></h5>
 <div class="sect5">
-<h6 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2_response_body"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2_response_body">Response body</a></h6>
+<h6 id="_response팀원들이_모두_이미지_업로드가_된_상태일_때_response_body"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_된_상태일_때_response_body">Response body</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code>{
@@ -1029,7 +1029,7 @@ Content-Length: 228
 </div>
 </div>
 <div class="sect5">
-<h6 id="_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2_response_fields"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_안된_상태일_때_2_response_fields">Response fields</a></h6>
+<h6 id="_response팀원들이_모두_이미지_업로드가_된_상태일_때_response_fields"><a class="link" href="#_response팀원들이_모두_이미지_업로드가_된_상태일_때_response_fields">Response fields</a></h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -1113,7 +1113,7 @@ Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
 Content-Type: application/json
 Transfer-Encoding: chunked
-Date: Sun, 26 Mar 2023 12:57:49 GMT
+Date: Tue, 04 Apr 2023 07:41:33 GMT
 Keep-Alive: timeout=60
 Connection: keep-alive
 Content-Length: 482
@@ -1237,7 +1237,10 @@ Content-Length: 482
 <pre class="highlight nowrap"><code>{
   "code" : "T-F002",
   "message" : "현재 등록된 이미지 수가 지정된 멤버 수보다 적습니다.",
-  "data" : null
+  "data" : {
+    "submit" : 3,
+    "numberOfTeam" : 5
+  }
 }</code></pre>
 </div>
 </div>
@@ -1260,9 +1263,9 @@ Content-Length: 482
 <div class="sect3">
 <h4 id="_200_ok_5"><a class="link" href="#_200_ok_5">200 OK</a></h4>
 <div class="sect4">
-<h5 id="_request이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우"><a class="link" href="#_request이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우">Request(이미지 제출 수 미충족, 성공, 올바른 auth_cde를 입력한 경우)</a></h5>
+<h5 id="_request이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우"><a class="link" href="#_request이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우">Request(이미지 제출 수 미충족, 성공, 올바른 auth_code를 입력한 경우)</a></h5>
 <div class="sect5">
-<h6 id="_request이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우_http_request"><a class="link" href="#_request이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우_http_request">HTTP request</a></h6>
+<h6 id="_request이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우_http_request"><a class="link" href="#_request이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우_http_request">HTTP request</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /teams/2/results?auth_code=1234 HTTP/1.1
@@ -1274,9 +1277,9 @@ Host: localhost</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우"><a class="link" href="#_response이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우">Response(이미지 제출 수 미충족, 성공, 올바른 auth_cde를 입력한 경우)</a></h5>
+<h5 id="_response이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우"><a class="link" href="#_response이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우">Response(이미지 제출 수 미충족, 성공, 올바른 auth_code를 입력한 경우)</a></h5>
 <div class="sect5">
-<h6 id="_response이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우_response_body"><a class="link" href="#_response이미지_제출_수_미충족_성공_올바른_auth_cde를_입력한_경우_response_body">Response body</a></h6>
+<h6 id="_response이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우_response_body"><a class="link" href="#_response이미지_제출_수_미충족_성공_올바른_auth_code를_입력한_경우_response_body">Response body</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code>{
@@ -1304,9 +1307,9 @@ Host: localhost</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_request이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우"><a class="link" href="#_request이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우">Request(이미지 제출 수 미충족, 실패, 잘못된 auth_cde를 입력한 경우)</a></h5>
+<h5 id="_request이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우"><a class="link" href="#_request이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우">Request(이미지 제출 수 미충족, 실패, 잘못된 auth_code를 입력한 경우)</a></h5>
 <div class="sect5">
-<h6 id="_request이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우_http_request"><a class="link" href="#_request이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우_http_request">HTTP request</a></h6>
+<h6 id="_request이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우_http_request"><a class="link" href="#_request이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우_http_request">HTTP request</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /teams/4/results?auth_code=5678 HTTP/1.1
@@ -1318,9 +1321,9 @@ Host: localhost</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_response이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우"><a class="link" href="#_response이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우">Response(이미지 제출 수 미충족, 실패, 잘못된 auth_cde를 입력한 경우)</a></h5>
+<h5 id="_response이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우"><a class="link" href="#_response이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우">Response(이미지 제출 수 미충족, 실패, 잘못된 auth_code를 입력한 경우)</a></h5>
 <div class="sect5">
-<h6 id="_response이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우_response_body"><a class="link" href="#_response이미지_제출_수_미충족_실패_잘못된_auth_cde를_입력한_경우_response_body">Response body</a></h6>
+<h6 id="_response이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우_response_body"><a class="link" href="#_response이미지_제출_수_미충족_실패_잘못된_auth_code를_입력한_경우_response_body">Response body</a></h6>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code>{

--- a/mogong/src/test/java/hufs/team/mogong/docs/team/TeamResultTest.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/team/TeamResultTest.java
@@ -12,6 +12,7 @@ import hufs.team.mogong.image.Image;
 import hufs.team.mogong.image.repository.ImageRepository;
 import hufs.team.mogong.team.Team;
 import hufs.team.mogong.team.repository.TeamRepository;
+import hufs.team.mogong.team.service.dto.response.SubmitResponse;
 import hufs.team.mogong.tool.RestTemplateMocks;
 import java.io.IOException;
 import org.hamcrest.Matchers;
@@ -38,6 +39,7 @@ class TeamResultTest extends InitDocumentationTest {
 
 	private Long teamId;
 	private Team team;
+	private int sizeOfImages;
 
 	@BeforeEach
 	void init() throws IOException {
@@ -54,6 +56,7 @@ class TeamResultTest extends InitDocumentationTest {
 		imageRepository.save(
 			new Image(team, "https://mogong.s3.ap-northeast-2.amazonaws.com/image/sample_3.JPG")
 		);
+		sizeOfImages = 3;
 		RestTemplateMocks.setUpResponses();
 	}
 
@@ -106,7 +109,6 @@ class TeamResultTest extends InitDocumentationTest {
 			.statusCode(HttpStatus.OK.value())
 			.body("code", Matchers.equalTo(NOT_COMPLETED_SUBMIT.getCode()))
 			.body("message", Matchers.equalTo(NOT_COMPLETED_SUBMIT.getMessage()))
-			.body("data", Matchers.equalTo(null))
 			.log().all();
 	}
 

--- a/mogong/src/test/resources/application.yml
+++ b/mogong/src/test/resources/application.yml
@@ -38,3 +38,4 @@ cloud:
 
 image-server:
   url: https://www.dummy.site/teams/{teamId}
+  validate: http://www.dummy.site/validate


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #14

<br><br>

### 📝 구현 내용

- Flask 서버에 이미지 검증 요청 부분 완성(현재는 Flask 서버가 완성되지 않았으므로 주석처리 해놓음)
- 클라이언트 측에서 결과 요청시 제출 수와 팀 전체 인원 수를 함께 보내도록 변경
- 자잘한 API 문서 오타 수정

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- (리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

<br><br>

### 💡 참고 자료

- (없다면 지워도 됩니다!)
