### PR TITLE
멤버 리더 표시 완료 및 API 문서 반영

### DIFF
--- a/mogong/src/main/java/hufs/team/mogong/member/Member.java
+++ b/mogong/src/main/java/hufs/team/mogong/member/Member.java
@@ -30,10 +30,12 @@ public class Member {
 	private Team team;
 
 	private boolean submit  = false;
+	private boolean leader = false;
 
-	public Member(String nickName, Team team) {
+	public Member(String nickName, Team team, boolean leader) {
 		this.nickName = nickName;
 		this.team = team;
+		this.leader = leader;
 	}
 
 	public void submit() {

--- a/mogong/src/main/java/hufs/team/mogong/member/service/MemberService.java
+++ b/mogong/src/main/java/hufs/team/mogong/member/service/MemberService.java
@@ -67,7 +67,8 @@ public class MemberService {
 
 		Team team = findTeamByTeamId(teamId);
 
-		Member savedMember = memberRepository.save(new Member(request.getNickName(), team));
+		Member savedMember = memberRepository.save(
+			new Member(request.getNickName(), team, request.isLeader()));
 		log.debug("[MEMBER CREATE] MEMBER SAVE 성공");
 
 		MemberImage savedImage = memberImageRepository.save(new MemberImage(savedMember, getPreSignedUrl(teamId)));
@@ -77,7 +78,8 @@ public class MemberService {
 			savedMember.getMemberId(),
 			savedMember.getNickName(),
 			savedImage.getUrl(),
-			savedMember.isSubmit());
+			savedMember.isSubmit(),
+			savedMember.isLeader());
 	}
 
 	private String getPreSignedUrl(long teamId) {
@@ -98,7 +100,9 @@ public class MemberService {
 			member.getMemberId(),
 			member.getNickName(),
 			image.getUrl(),
-			member.isSubmit());
+			member.isSubmit(),
+			member.isLeader()
+		);
 	}
 
 	@Transactional
@@ -121,7 +125,8 @@ public class MemberService {
 				team.getNumberOfSubmit(),
 				member.getNickName(),
 				image.getUrl(),
-				Boolean.TRUE);
+				Boolean.TRUE,
+				member.isLeader());
 		}
 
 		timeTableV1.get().update(times);
@@ -132,7 +137,8 @@ public class MemberService {
 			team.getNumberOfSubmit(),
 			member.getNickName(),
 			image.getUrl(),
-			Boolean.TRUE);
+			Boolean.TRUE,
+			member.isLeader());
 	}
 
 	@Transactional
@@ -155,7 +161,8 @@ public class MemberService {
 				team.getNumberOfSubmit(),
 				member.getNickName(),
 				image.getUrl().split("\\?")[0],
-				Boolean.TRUE);
+				Boolean.TRUE,
+				member.isLeader());
 		}
 
 		timeTableV2.get().update(times);
@@ -166,7 +173,8 @@ public class MemberService {
 			team.getNumberOfSubmit(),
 			member.getNickName(),
 			image.getUrl(),
-			Boolean.TRUE);
+			Boolean.TRUE,
+			member.isLeader());
 	}
 
 	private List<String> requestImageProcessingV1(Team team, Member member, MemberImage image) {
@@ -190,7 +198,7 @@ public class MemberService {
 
 	private List<Long> requestImageProcessingV2(Team team, Member member, MemberImage image) {
 		ImageServerTimeResponses timeResponses = getTimeResponses(team, member, image);
-		log.debug(timeResponses.toString());
+		log.debug("TIME RESPONSES={}", timeResponses.toString());
 		TimeTableResponse[] times = timeResponses.getTimes();
 		List<Long> timeResults = new ArrayList<>();
 		StringBuilder sb = new StringBuilder();

--- a/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberImageUploadResponse.java
+++ b/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberImageUploadResponse.java
@@ -14,4 +14,5 @@ public class MemberImageUploadResponse {
 	private final String nickName;
 	private final String imageUrl;
 	private final boolean submit;
+	private final boolean leader;
 }

--- a/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberResponse.java
+++ b/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberResponse.java
@@ -13,4 +13,6 @@ public class MemberResponse {
 	private final String imageUrl;
 	private final boolean submit;
 
+	private final boolean leader;
+
 }

--- a/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberResultResponse.java
+++ b/mogong/src/main/java/hufs/team/mogong/member/service/dto/response/MemberResultResponse.java
@@ -12,5 +12,6 @@ public class MemberResultResponse {
 	private final Long memberId;
 	private final String nickName;
 	private final boolean submit;
+	private final boolean leader;
 
 }

--- a/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
+++ b/mogong/src/main/java/hufs/team/mogong/team/service/TeamService.java
@@ -129,7 +129,7 @@ public class TeamService {
 
 		List<MemberResultResponse> memberResultResponses = members.stream()
 			.map(m -> {log.debug("MEMBER ID={}의 이미지 조회", m.getMemberId());
-				return new MemberResultResponse(m.getMemberId(), m.getNickName(), m.isSubmit());})
+				return new MemberResultResponse(m.getMemberId(), m.getNickName(), m.isSubmit(), m.isLeader());})
 			.collect(Collectors.toList());
 
 		TimeResponses timeResponses = getTeamResult(team, members, isV1, authCode);

--- a/mogong/src/test/java/hufs/team/mogong/docs/member/FindMemberTest.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/member/FindMemberTest.java
@@ -61,7 +61,7 @@ class FindMemberTest extends InitDocumentationTest {
 		teamId = team.getTeamId();
 
 
-		member = memberRepository.save(new Member("dummy_nickname", team));
+		member = memberRepository.save(new Member("dummy_nickname", team, true));
 		memberId = member.getMemberId();
 
 		memberImageRepository.save(new MemberImage(member, "https://aws.s3.dummy-img/teams/1/dummy_img.jpeg"));

--- a/mogong/src/test/java/hufs/team/mogong/docs/member/MemberImageUploadTest.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/member/MemberImageUploadTest.java
@@ -62,7 +62,7 @@ class MemberImageUploadTest extends InitDocumentationTest {
 		teamImageRepository.save(new TeamImage(team, "https://aws.s3.dummy-img.jpeg"));
 		teamId = team.getTeamId();
 
-		member = memberRepository.save(new Member("dummy_nickname", team));
+		member = memberRepository.save(new Member("dummy_nickname", team, true));
 		memberId = member.getMemberId();
 		memberImageRepository.save(new MemberImage(member, "https://aws.s3.dummy-img/teams/1/dummy_img.jpeg"));
 

--- a/mogong/src/test/java/hufs/team/mogong/docs/member/MemberSnippet.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/member/MemberSnippet.java
@@ -27,7 +27,8 @@ public interface MemberSnippet {
 			fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("생성된 팀원 아이디"),
 			fieldWithPath("nickName").type(JsonFieldType.STRING).description("생성된 팀원 이름"),
 			fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("생성된 팀원의 이미지 URL"),
-			fieldWithPath("submit").type(JsonFieldType.BOOLEAN).description("생성된 팀원의 이미지 업로드 여부(default: false)")
+			fieldWithPath("submit").type(JsonFieldType.BOOLEAN).description("생성된 팀원의 이미지 업로드 여부(default: false)"),
+			fieldWithPath("leader").type(JsonFieldType.BOOLEAN).description("팀장 여부")
 		)
 	);
 
@@ -40,7 +41,8 @@ public interface MemberSnippet {
 			fieldWithPath("numberOfSubmit").type(JsonFieldType.NUMBER).description("이미지 업로드 수"),
 			fieldWithPath("nickName").type(JsonFieldType.STRING).description("팀원 이름"),
 			fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("팀원 이미지 URL"),
-			fieldWithPath("submit").type(JsonFieldType.BOOLEAN).description("팀원의 이미지 업로드 여부")
+			fieldWithPath("submit").type(JsonFieldType.BOOLEAN).description("팀원의 이미지 업로드 여부"),
+			fieldWithPath("leader").type(JsonFieldType.BOOLEAN).description("팀장 여부")
 		)
 	);
 

--- a/mogong/src/test/java/hufs/team/mogong/docs/team/FindTeamTest.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/team/FindTeamTest.java
@@ -88,8 +88,8 @@ class FindTeamTest extends InitDocumentationTest {
 	}
 
 	private void saveMember() {
-		member1 = memberRepository.save(new Member("dummy_nickname-1", team));
-		member2 = memberRepository.save(new Member("dummy_nickname-2", team));
+		member1 = memberRepository.save(new Member("dummy_nickname-1", team, true));
+		member2 = memberRepository.save(new Member("dummy_nickname-2", team, false));
 		memberImageRepository.save(new MemberImage(member1,
 			"https://mogong.s3.ap-northeast-2.amazonaws.com/image/sample_2.JPG"));
 		memberImageRepository.save(new MemberImage(member2,

--- a/mogong/src/test/java/hufs/team/mogong/docs/team/TeamSnippet.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/team/TeamSnippet.java
@@ -46,6 +46,7 @@ public interface TeamSnippet {
 			fieldWithPath("members[].memberId").type(JsonFieldType.NUMBER).description("팀원 ID"),
 			fieldWithPath("members[].nickName").type(JsonFieldType.STRING).description("팀원 이름"),
 			fieldWithPath("members[].submit").type(JsonFieldType.BOOLEAN).description("팀원 이미지 업로드 현황"),
+			fieldWithPath("members[].leader").type(JsonFieldType.BOOLEAN).description("팀장 여부"),
 			fieldWithPath("resultImageUrl").type(JsonFieldType.STRING).description("결과 이미지 URL"),
 			fieldWithPath("timeResponses").type(JsonFieldType.OBJECT).description("N분 단위의 시간들"),
 			fieldWithPath("timeResponses.divisorMinutes").type(JsonFieldType.NUMBER).description("시간 단위 (default : 30분)"),

--- a/mogong/src/test/java/hufs/team/mogong/docs/vote/InitVoteTest.java
+++ b/mogong/src/test/java/hufs/team/mogong/docs/vote/InitVoteTest.java
@@ -82,8 +82,8 @@ public abstract class InitVoteTest extends InitDocumentationTest {
 	}
 
 	protected void saveMember() {
-		member1 = memberRepository.save(new Member("dummy_nickname-1", team));
-		member2 = memberRepository.save(new Member("dummy_nickname-2", team));
+		member1 = memberRepository.save(new Member("dummy_nickname-1", team, true));
+		member2 = memberRepository.save(new Member("dummy_nickname-2", team, false));
 		memberImageRepository.save(new MemberImage(member1,
 			"https://mogong.s3.ap-northeast-2.amazonaws.com/image/sample_2.JPG"));
 		memberImageRepository.save(new MemberImage(member2,


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #26

<br><br>

### 📝 구현 내용

- 멤버(팀원) 생성시 팀장 여부를 확인할 수 있는 `leader(Boolean)` 필드 추가

<br><br>

### 💡 참고 자료

<img width="522" alt="image" src="https://github.com/allrounded/spring-server/assets/67811880/46b7e6d8-0eb1-41b1-9c64-a8a3098ae27c">

